### PR TITLE
FreeCAD: Check method existance instead of revision

### DIFF
--- a/backends/freecad/gui/freecad_bolts.py
+++ b/backends/freecad/gui/freecad_bolts.py
@@ -344,8 +344,7 @@ class BoltsWidget(QBoltsWidget):
 				if params[key] is None:
 					#A undefined value is not necessarily fatal
 					continue
-				revision = int(FreeCAD.Version()[2].split()[0])
-				if revision >= 2836:
+				if hasattr(FreeCAD.Units, "parseQuantity"):
 					params[key] = FreeCAD.Units.parseQuantity("%g %s" %
 						(params[key], lengths[tp])).Value
 				else:


### PR DESCRIPTION
Fixes exception when attempting to add part on some distributions,
notably Arch Linux, where revision parameter of the FreeCAD version is incorrect.
Previous code then caused ValueError: invalid literal for int() with base 10: '$WCREV$'
Arguably also more "Pythonic" to check for features needed instead of version.