### PR TITLE
Added reference to error "ImportError: No module named pysideuic".

### DIFF
--- a/website/docs/sources/0.3/freecad/installation.md
+++ b/website/docs/sources/0.3/freecad/installation.md
@@ -54,6 +54,10 @@ version for the python version bundled with FreeCAD.
 If you get a message that says
 
     uic import failed. Make sure that the pyside tools are installed
+    
+or an error message that says
+
+    ImportError: No module named pysideuic
 
 then there is a part of the PySide Qt bindings missing. For Debian and Ubuntu
 this is contained in the package pyside-tools.


### PR DESCRIPTION
I added a reference to a specific error message that I received that wasn't on the installtion.md page.